### PR TITLE
Cotel day6

### DIFF
--- a/cotel/src/main/scala/day6/package.scala
+++ b/cotel/src/main/scala/day6/package.scala
@@ -1,0 +1,34 @@
+import scala.annotation.tailrec
+
+package object day6 {
+
+  @tailrec def balanceBanks(banks: List[Int], checkedStates: List[String] = Nil, steps: Int = 0): Int = {
+    if (banks.distinct.size == 1) return steps
+
+    val currentState = banksRepresentation(banks)
+    if (checkedStates.contains(currentState)) return steps
+
+    val newBanks: List[Int] = balanceStep(banks)
+
+    balanceBanks(newBanks, currentState :: checkedStates, steps+1)
+  }
+
+  def balanceStep(banks: List[Int]): List[Int] = {
+    val maxBank = banks.max
+    val indexOfMax = banks.indexOf(maxBank)
+
+    val firstLoop = indexOfMax+1 until banks.size toList
+    val cycleStream = Stream.continually(banks.indices toStream)
+      .flatten
+      .take(maxBank - firstLoop.size)
+      .toList
+    val indicesCycled = firstLoop ::: cycleStream
+
+    var newBanks = banks.updated(indexOfMax, 0)
+    for (i <- indicesCycled) newBanks = newBanks.updated(i, newBanks(i)+1)
+    newBanks
+  }
+
+  private def banksRepresentation(banks: List[Int]): String = banks.mkString(" ")
+
+}

--- a/cotel/src/main/scala/day6/package.scala
+++ b/cotel/src/main/scala/day6/package.scala
@@ -2,33 +2,55 @@ import scala.annotation.tailrec
 
 package object day6 {
 
-  @tailrec def balanceBanks(banks: List[Int], checkedStates: List[String] = Nil, steps: Int = 0): Int = {
+  @tailrec def balanceBanks(banks: List[Int], checkedStates: List[List[Int]] = Nil, steps: Int = 0): Int = {
     if (banks.distinct.size == 1) return steps
 
-    val currentState = banksRepresentation(banks)
-    if (checkedStates.contains(currentState)) return steps
+    if (checkedStates.contains(banks)) return steps
 
-    val newBanks: List[Int] = balanceStep(banks)
+    val newBanks: List[Int] = balanceStepv2(banks)
 
-    balanceBanks(newBanks, currentState :: checkedStates, steps+1)
+    balanceBanks(newBanks, banks :: checkedStates, steps+1)
+  }
+
+  @tailrec def stepsUntilSameState(banks: List[Int], checkedStates: List[List[Int]] = Nil, steps: Int = 0): (Int, List[Int]) = {
+    if (checkedStates.contains(banks)) return (steps, banks)
+
+    stepsUntilSameState(balanceStep(banks), banks :: checkedStates, steps+1)
   }
 
   def balanceStep(banks: List[Int]): List[Int] = {
+    var (i, number) = (banks.indexOf(banks.max), banks.max)
+    val distribution = if (number < banks.size) number else banks.size -1
+
+    val blocksForEach = number / distribution
+    val displacement = blocksForEach * distribution
+
+    var list = banks.updated(i, number - displacement)
+    i += 1
+
+    for (j <- 1 to distribution) {
+      i %= banks.size
+      list = list.updated(i, list(i) + blocksForEach)
+      i +=1
+    }
+
+    list
+  }
+
+  def balanceStepv2(banks: List[Int]): List[Int] = {
     val maxBank = banks.max
     val indexOfMax = banks.indexOf(maxBank)
 
-    val firstLoop = indexOfMax+1 until banks.size toList
+    val firstLoop = indexOfMax + 1 until banks.size toList
     val cycleStream = Stream.continually(banks.indices toStream)
       .flatten
-      .take(maxBank - firstLoop.size)
+      .take(maxBank)
       .toList
-    val indicesCycled = firstLoop ::: cycleStream
+    val indicesCycled = (firstLoop ::: cycleStream).take(maxBank)
 
     var newBanks = banks.updated(indexOfMax, 0)
-    for (i <- indicesCycled) newBanks = newBanks.updated(i, newBanks(i)+1)
+    for (i <- indicesCycled) newBanks = newBanks.updated(i, newBanks(i) + 1)
     newBanks
   }
-
-  private def banksRepresentation(banks: List[Int]): String = banks.mkString(" ")
 
 }

--- a/cotel/src/test/scala/day6/MemoryReallocationTest.scala
+++ b/cotel/src/test/scala/day6/MemoryReallocationTest.scala
@@ -1,0 +1,22 @@
+package day6
+
+import org.scalatest.{FunSuite, Matchers}
+
+class MemoryReallocationTest extends FunSuite with Matchers {
+  import day6._
+
+  test("Banks [0, 2, 7, 0] should be balanced in 5 steps") {
+    balanceBanks(List(0,2,7,0)) shouldBe 5
+  }
+
+  test("Banks [1, 1, 1] should be balanced in 0 steps") {
+    balanceBanks(List(1,1,1)) shouldBe 0
+  }
+
+  // Helper methods
+
+  test("Balance step for Bank [0, 2, 7, 0] should result in [2, 4, 1, 2]") {
+    balanceStep(List(0, 2, 7, 0)) shouldBe List(2,4,1,2)
+  }
+
+}

--- a/cotel/src/test/scala/day6/MemoryReallocationTest.scala
+++ b/cotel/src/test/scala/day6/MemoryReallocationTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.{FunSuite, Matchers}
 class MemoryReallocationTest extends FunSuite with Matchers {
   import day6._
 
+  // Part 1
+
   test("Banks [0, 2, 7, 0] should be balanced in 5 steps") {
     balanceBanks(List(0,2,7,0)) shouldBe 5
   }
@@ -13,10 +15,33 @@ class MemoryReallocationTest extends FunSuite with Matchers {
     balanceBanks(List(1,1,1)) shouldBe 0
   }
 
+  test("Banks [2, 0, 0] should be balanced in 6") {
+    balanceBanks(List(2,0,0)) shouldBe 6
+  }
+
+  // Part 2
+
+  test("Banks [2, 4, 1, 2] should appear again after 4 steps in [0, 2, 7, 0]") {
+    val tuple = stepsUntilSameState(List(0, 2, 7, 0))
+    stepsUntilSameState(tuple._2)._1 shouldBe 4
+  }
+
   // Helper methods
 
   test("Balance step for Bank [0, 2, 7, 0] should result in [2, 4, 1, 2]") {
     balanceStep(List(0, 2, 7, 0)) shouldBe List(2,4,1,2)
+  }
+
+  test("Balance step (v2) for Bank [0, 2, 7, 0] should result in [2, 4, 1, 2]") {
+    balanceStepv2(List(0, 2, 7, 0)) shouldBe List(2,4,1,2)
+  }
+
+  test("Balance step for Bank [2, 0, 0] should result in [0, 1, 1]") {
+    balanceStepv2(List(2, 0, 0)) shouldBe List(0, 1, 1)
+  }
+
+  test("Balance step for Bank [1, 1, 0] should result in [0, 2, 0]") {
+    balanceStepv2(List(1, 1, 0)) shouldBe List(0, 2, 0)
   }
 
 }


### PR DESCRIPTION
# Cotel's solution for day 6 challenge

## Description

In today's problem, we need to figure out when a balancing process of an array will be stuck in an infinite loop.

Part 2 consists in, for an appearing state in this balancing progress, get the next step in which it will appear.

## Solution

Two parts:

1. The recursion for triggering the algorithm:

* If all the items in the bank are the same it means it is balanced so we exit
* If the current bank is already included in the checked states then it means we just entered in an infinite loop so we exit
* Else we call the balance algorithm and then we call the recursion appending the current state in the checked states.

```scala
@tailrec def balanceBanks(banks: List[Int], checkedStates: List[List[Int]] = Nil, steps: Int = 0): Int = {
    if (banks.distinct.size == 1) return steps

    if (checkedStates.contains(banks)) return steps

    val newBanks: List[Int] = balanceStep(banks)

    balanceBanks(newBanks, banks :: checkedStates, steps+1)
  }
```

2. Balancing algorithm

First we need to get the max item of the bank and its position:

```scala
val maxBank = banks.max
val indexOfMax = banks.indexOf(maxBank)
```

Then we get the indices of the first loop until the end of the bank from the `maxBank` position:

```scala
val firstLoop = indexOfMax + 1 until banks.size toList
```

Now we need to cycle the indices of the list. I.e `[0,1,2,0,1,2,0,1,2, ...]`. Scala allows to do this like Haskell, the difference here is that Scala has eager evaluation so it produces an infinite stream. We need to cut it somewhere to be used so we take `maxBank` for example, but we could take 100.

```scala
val cycleStream = Stream.continually(banks.indices toStream)
      .flatten
      .take(maxBank)
      .toList
```

Then we prepend the first loop and this time we take `maxBank` exactly. Because we can iterate this cycle `maxBank` times to increment positions in the bank.

```scala
val indicesCycled = (firstLoop ::: cycleStream).take(maxBank)
```

And now we iterate through this indices and update the bank along the iteration:

```scala
var newBanks = banks.updated(indexOfMax, 0)
for (i <- indicesCycled) newBanks = newBanks.updated(i, newBanks(i) + 1)
```

I'm sure this is an overkill, but it is declarative 👍 

Part 2 is the same as part 1. We need to find the first appearance of the desired sequence. Once we have it, we solve the problem again with this sequence as input. This way we find when this input appears again if the balancing algorithm goes infinite.

## Tests battery

Tests today were a lifesaver. At first this balancing algorithm wasn't working and thanks to the tests cases I wrote I was able to find the error 💯 

**Tests for the entire problem**

```scala
test("Banks [0, 2, 7, 0] should be balanced in 5 steps") {
    balanceBanks(List(0,2,7,0)) shouldBe 5
  }

  test("Banks [1, 1, 1] should be balanced in 0 steps") {
    balanceBanks(List(1,1,1)) shouldBe 0
  }

  test("Banks [2, 0, 0] should be balanced in 6") {
    balanceBanks(List(2,0,0)) shouldBe 6
  }
```

**Tests for the balancing algorithm**

```scala
test("Balance step (v2) for Bank [0, 2, 7, 0] should result in [2, 4, 1, 2]") {
    balanceStepv2(List(0, 2, 7, 0)) shouldBe List(2,4,1,2)
  }

  test("Balance step for Bank [2, 0, 0] should result in [0, 1, 1]") {
    balanceStepv2(List(2, 0, 0)) shouldBe List(0, 1, 1)
  }

  test("Balance step for Bank [1, 1, 0] should result in [0, 2, 0]") {
    balanceStepv2(List(1, 1, 0)) shouldBe List(0, 2, 0)
  }
```

Happy Advent of Code!